### PR TITLE
fix(homepages): fix the horizontal scrollbar on the homepages

### DIFF
--- a/app/components/AppHero.vue
+++ b/app/components/AppHero.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="relative w-screen overflow-hidden py-32">
+    <section class="relative overflow-hidden py-32">
         <div class="container relative flex flex-col lg:flex-row">
             <div class="mt-10 space-y-12 lg:w-1/2">
                 <!--                <p class="bg-muted w-fit rounded-full px-4 py-1 text-sm"> -->


### PR DESCRIPTION
- In the case of vertical scrollbars on Windows systems, 100vw will be wider than actual, resulting in the appearance of bus scrollbars
- And the width of the section label itself defaults to 100%, so there is no need to set an additional w-screen
- The Mac system will not have this issue

| Before | After |
|--------|-------|
| <img width="1920" height="869" alt="da76340530c8430ef67ee7917b6c8096" src="https://github.com/user-attachments/assets/8d05b3eb-cad4-4c58-baa5-d2687a0cd7b9" /> | <img width="1920" height="869" alt="25e7b15d62efc1f027377f6db9fff716" src="https://github.com/user-attachments/assets/2766fa7c-4233-4fbf-8b8e-1dcb8d1e01c8" />|